### PR TITLE
Fix loss of PU override properties

### DIFF
--- a/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/AriesEntityManagerFactoryBuilder.java
+++ b/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/AriesEntityManagerFactoryBuilder.java
@@ -83,6 +83,7 @@ public class AriesEntityManagerFactoryBuilder implements EntityManagerFactoryBui
 
 	private boolean complete;
 
+	private Map<String, Object> overrides;
 
 
 	public AriesEntityManagerFactoryBuilder(BundleContext containerContext, PersistenceProvider provider, Bundle providerBundle, PersistenceUnit persistenceUnit) {
@@ -210,7 +211,11 @@ public class AriesEntityManagerFactoryBuilder implements EntityManagerFactoryBui
 		for(String key : punitProps.stringPropertyNames()) {
 			processed.put(key, punitProps.get(key));
 		}
-		
+		synchronized (this) {
+			if (overrides != null) {
+				processed.putAll(overrides);
+			}
+		}
 		if(props != null) {
 			processed.putAll(props);
 		}
@@ -536,5 +541,9 @@ public class AriesEntityManagerFactoryBuilder implements EntityManagerFactoryBui
 			props.put(JAVAX_PERSISTENCE_NON_JTA_DATASOURCE, ds);
 		}
 		createEntityManagerFactory(props);
+	}
+
+	public synchronized void setOverrides(Map<String, Object> overrides) {
+		this.overrides = overrides;
 	}
 }

--- a/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/ManagedEMF.java
+++ b/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/ManagedEMF.java
@@ -71,7 +71,7 @@ public class ManagedEMF implements ManagedService {
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug("Using properties override {}", overrides);
 		}
-		
+		builder.setOverrides(overrides);
 		builder.createEntityManagerFactory(overrides);
 		configured.set(true);
 	}


### PR DESCRIPTION
Memorize override PU props even if the required DataSource is not yet
available. Always merge the memorized props into the static PU props
before publishing an EntityManagerFactory.
We have hold on to the override props although we might not yet be able
to create an EntityManagerFactory, since we will not be notified about
the updated props again.

Resolves: ARIES-1992